### PR TITLE
Handle EOFError in getpass, and don't send notification email to blank email.

### DIFF
--- a/gold.py
+++ b/gold.py
@@ -66,7 +66,7 @@ class Gold(object):
                 else:
                     print("> Login successful.")
                     break
-            except KeyboardInterrupt:
+            except (EOFError, KeyboardInterrupt):
                 print(self.exit_msg)
                 exit()
             except:
@@ -140,8 +140,11 @@ class Gold(object):
                 elif info_dict["Space"] == u"Closed\xa0":
                     print("Class closed. You should search for another class.")
                 elif (float(info_dict["Space"]) / float(info_dict["Max"])) > 0:
-                    print("Class is OPEN! Sending notification...")
-                    self.notify(title)
+                    if self.notify_email:
+                        print("Class is OPEN! Sending notification...")
+                        self.notify(title)
+                    else:
+                        print("Class is OPEN!")
                 else:
                     print("Unknown reason why class is full.")
             except mechanize._form.ControlNotFoundError:


### PR DESCRIPTION
- It appears on OS X ctrl+c will not terminate getpass, thus the only way to break
  out of the loop is to close the input stream (via ctrl+d). This addition properly
  exits the program when the input stream is closed.
- Do not attempt to send an email when the email field is not set.
